### PR TITLE
Fix response header content type

### DIFF
--- a/stubby/Portals/PortalUtils.cs
+++ b/stubby/Portals/PortalUtils.cs
@@ -49,7 +49,7 @@ namespace stubby.Portals {
         }
 
         public static void SetJsonType(HttpListenerContext context) {
-            context.Response.Headers.Set(HttpRequestHeader.ContentType, JsonMimeType);
+            context.Response.Headers.Set(HttpResponseHeader.ContentType, JsonMimeType);
         }
 
         public static void SetHtmlType(HttpListenerContext context) {


### PR DESCRIPTION
Using the HttpRequestHeader.ContentType key throws an
InvalidOperationException. with the message "This collection holds
response headers and cannot contain the specified request header."
