### PR TITLE
[gk] - adding endpoint invocation tracking and querying admin resource

### DIFF
--- a/integration/InvocationsTest.cs
+++ b/integration/InvocationsTest.cs
@@ -1,0 +1,275 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Web.Script.Serialization;
+using NUnit.Framework;
+using stubby;
+using stubby.Domain;
+
+namespace integration
+{
+	[TestFixture]
+	public class InvocationsTest
+	{
+		private readonly Stubby _stubby = new Stubby(new Arguments
+		{
+			Admin = 9999,
+			Stubs = 9992,
+			Mute = true,
+			Data = "../../YAML/invocations.yaml"
+		});
+
+		[TestFixtureSetUp]
+		public void Before()
+		{
+			_stubby.Start();
+		}
+
+		[TestFixtureTearDown]
+		public void After()
+		{
+			_stubby.Stop();
+		}
+
+		[Test]
+		public void BasicGETWithTenantId_ShouldReturnOK()
+		{
+			var tenantId = Guid.NewGuid().ToString();
+			WebRequest.Create("http://localhost:9992/basic")
+				.AddHeader("tenantId", tenantId)
+				.Get();
+
+			WebRequest.Create("http://localhost:9992/basic")
+				.AddHeader("tenantId", tenantId)
+				.Get();
+
+			var invocations = WebRequest.Create("http://localhost:9999/invocations/basic")
+				.AddIgnoreHeaders()
+				.AddHeader("tenantId", tenantId)
+				.InvocationsGet();
+
+			Assert.That(invocations.Count, Is.EqualTo(2));
+			foreach (var invocation in invocations)
+			{
+				Assert.That(invocation.Headers["tenantid"][0], Is.EqualTo(tenantId));
+			}
+		}
+
+		[Test]
+		public void BasicGETWithQueryString_ShouldReturnOK()
+		{
+			const string postData = "This is a test that posts this string to a Web server.";
+			var tenantId = Guid.NewGuid().ToString();
+			var value1 = Guid.NewGuid().ToString();
+			var value2 = Guid.NewGuid().ToString();
+			WebRequest.Create(String.Format("http://localhost:9992/basic?key1={0}&key2={1}", value1, value2))
+				.AddHeader("tenantId", tenantId)
+				.Post(postData);
+
+			WebRequest.Create(String.Format("http://localhost:9992/basic?key1={0}&key2={1}", value1, value2))
+				.AddHeader("tenantId", tenantId + "something-else")
+				.Get();
+
+			WebRequest.Create("http://localhost:9992/basic?key1=value1&key2=value2")
+				.AddHeader("tenantId", tenantId)
+				.Get();
+
+			var invocations = WebRequest.Create(String.Format("http://localhost:9999/invocations/basic?key2={0}", value2))
+				.AddHeader("tenantId", tenantId)
+				.AddIgnoreHeaders()
+				.InvocationsPost();
+
+			Assert.That(invocations.Count, Is.EqualTo(1));
+			var invocation = invocations[0];
+			Assert.That(invocation.Method, Is.EqualTo("POST"));
+			Assert.That(invocation.Url, Is.EqualTo("/basic"));
+			Assert.That(invocation.Headers.Keys, Contains.Item("tenantid"));
+			Assert.That(invocation.Headers["tenantid"][0], Is.EqualTo(tenantId));
+			Assert.That(invocation.Post, Is.EqualTo(postData));
+		}
+
+		[Test]
+		public void BasicGET_POST_PUT_DELETE_ShouldReturnFilter()
+		{
+			var requestId = Guid.NewGuid();
+			WebRequest.Create("http://localhost:9992/basic")
+				.AddHeader("requestId", requestId.ToString())
+				.Delete();
+
+			WebRequest.Create("http://localhost:9992/basic")
+				.AddHeader("requestId", requestId.ToString())
+				.Get();
+
+			WebRequest.Create("http://localhost:9992/basic")
+				.AddHeader("requestId", requestId.ToString())
+				.Post();
+
+			WebRequest.Create("http://localhost:9992/basic")
+				.AddHeader("requestId", requestId.ToString())
+				.Put();
+
+			var invocations = WebRequest.Create("http://localhost:9999/invocations/basic")
+				.AddIgnoreHeaders()
+				.AddHeader("requestId", requestId.ToString())
+				.InvocationsDelete();
+
+			Assert.That(invocations.Count, Is.EqualTo(1));
+			var invocation = invocations[0];
+			Assert.That(invocation.Method, Is.EqualTo("DELETE"));
+			Assert.That(invocation.Url, Is.EqualTo("/basic"));
+			Assert.That(invocation.Headers.Keys, Contains.Item("requestid"));
+			Assert.That(invocation.Headers["requestid"][0], Is.EqualTo(requestId.ToString()));
+
+			invocations = WebRequest.Create("http://localhost:9999/invocations/basic")
+				.AddIgnoreHeaders()
+				.AddHeader("requestId", requestId.ToString())
+				.InvocationsPost();
+
+			Assert.That(invocations.Count, Is.EqualTo(1));
+			invocation = invocations[0];
+			Assert.That(invocation.Method, Is.EqualTo("POST"));
+			Assert.That(invocation.Url, Is.EqualTo("/basic"));
+			Assert.That(invocation.Headers.Keys, Contains.Item("requestid"));
+			Assert.That(invocation.Headers["requestid"][0], Is.EqualTo(requestId.ToString()));
+
+			invocations = WebRequest.Create("http://localhost:9999/invocations/basic")
+				.AddIgnoreHeaders()
+				.AddHeader("requestId", requestId.ToString())
+				.InvocationsPut();
+
+			Assert.That(invocations.Count, Is.EqualTo(1));
+			invocation = invocations[0];
+			Assert.That(invocation.Method, Is.EqualTo("PUT"));
+			Assert.That(invocation.Url, Is.EqualTo("/basic"));
+			Assert.That(invocation.Headers.Keys, Contains.Item("requestid"));
+			Assert.That(invocation.Headers["requestid"][0], Is.EqualTo(requestId.ToString()));
+
+			invocations = WebRequest.Create("http://localhost:9999/invocations/basic")
+				.AddIgnoreHeaders()
+				.AddHeader("requestId", requestId.ToString())
+				.InvocationsGet();
+
+			Assert.That(invocations.Count, Is.EqualTo(1));
+			invocation = invocations[0];
+			Assert.That(invocation.Method, Is.EqualTo("GET"));
+			Assert.That(invocation.Url, Is.EqualTo("/basic"));
+			Assert.That(invocation.Headers.Keys, Contains.Item("requestid"));
+			Assert.That(invocation.Headers["requestid"][0], Is.EqualTo(requestId.ToString()));
+		}
+	}
+
+	public static class TestExtensions
+	{
+		private static HttpWebResponse GetResponse(WebRequest request, string method, string body)
+		{
+			request.Method = method;
+			request.SetBody(body);
+			using (var response = (HttpWebResponse)request.GetResponse())
+			{
+				Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+				response.Close();
+				return response;
+			}
+		}
+
+		public static WebRequest AddIgnoreHeaders(this WebRequest request)
+		{
+			request.Headers.Add("x-ignore", "host");
+			request.Headers.Add("x-ignore", "connection");
+			request.Headers.Add("x-ignore", "content-length");
+			return request;
+		}
+
+		public static WebRequest AddHeader(this WebRequest request, string name, string value)
+		{
+			request.Headers.Add(name, value);
+			return request;
+		}
+
+		public static HttpWebResponse Post(this WebRequest request, string body = null)
+		{
+			return GetResponse(request, "POST", body);
+		}
+
+		public static HttpWebResponse Put(this WebRequest request, string body = null)
+		{
+			return GetResponse(request, "PUT", body);
+		}
+
+		public static HttpWebResponse Get(this WebRequest request)
+		{
+			return GetResponse(request, "GET", null);
+		}
+
+		public static HttpWebResponse Delete(this WebRequest request)
+		{
+			return GetResponse(request, "DELETE", null);
+		}
+
+		public static IList<Invocation> InvocationsPost(this WebRequest request, string body = null)
+		{
+			return LoadInvocations(request, "POST", body);
+		}
+
+		public static IList<Invocation> InvocationsGet(this WebRequest request, string body = null)
+		{
+			return LoadInvocations(request, "GET", body);
+		}
+
+		public static IList<Invocation> InvocationsPut(this WebRequest request, string body = null)
+		{
+			return LoadInvocations(request, "PUT", body);
+		}
+
+		public static IList<Invocation> InvocationsDelete(this WebRequest request, string body = null)
+		{
+			return LoadInvocations(request, "DELETE", body);
+		}
+
+		private static IList<Invocation> LoadInvocations(WebRequest request, string method, string body)
+		{
+			request.Method = method;
+			request.SetBody(body);
+			using (var response = (HttpWebResponse)request.GetResponse())
+			{
+				Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+				var responseStream = response.GetResponseStream();
+				if (responseStream == null)
+					return new List<Invocation>();
+
+				using (var reader = new StreamReader(responseStream))
+				{
+					var content = reader.ReadToEnd();
+					var serializer = new JavaScriptSerializer();
+					var invocations = serializer.Deserialize<List<Invocation>>(content);
+					return invocations;
+				}
+			}
+		}
+
+		private static WebRequest SetBody(this WebRequest request, string body = null)
+		{
+			switch (request.Method.ToLowerInvariant())
+			{
+				case "post":
+				case "put":
+					if (String.IsNullOrEmpty(body))
+					{
+						request.ContentLength = 0;
+					}
+					else
+					{
+						var byteArray = Encoding.UTF8.GetBytes(body);
+						request.ContentLength = byteArray.Length;
+						var dataStream = request.GetRequestStream();
+						dataStream.Write(byteArray, 0, byteArray.Length);
+						dataStream.Close();
+					}
+					break;
+			}
+			return request;
+		}
+	}
+}

--- a/integration/ViaFileTest.cs
+++ b/integration/ViaFileTest.cs
@@ -170,7 +170,7 @@ namespace integration {
         [Test]
         public void EndpointRespondsTo_DifferentQueryParameters_ForSameUrl() {
             const string expectedBody = "second query";
-            var request = WebRequest.Create("http://localhost:9992/get/query?first=value1again&second=value2again");
+            var request = WebRequest.Create("http://localhost:9992/get/query?first=valueagain1&second=valueagain2");
             var response = (HttpWebResponse) request.GetResponse();
             var actualBody = TestUtils.ExtractBody(response);
          
@@ -179,7 +179,7 @@ namespace integration {
         }
 
         [Test]
-        public void BasicAuthroization_IsConfigurableWith_Base64() {
+        public void BasicAuthorization_IsConfigurableWith_Base64() {
             const string expectedBody = "resource has been created";
             var request = WebRequest.Create("http://localhost:9992/post/auth");
             request.Method = "post";
@@ -194,7 +194,7 @@ namespace integration {
         }
 
         [Test]
-        public void BasicAuthroization_IsConfigurableWith_ColonNotation() {
+        public void BasicAuthorization_IsConfigurableWith_ColonNotation() {
             const string expectedBody = "resource has been created";
             var request = WebRequest.Create("http://localhost:9992/post/auth/pair");
             request.Method = "post";
@@ -209,7 +209,7 @@ namespace integration {
         }
 
         [Test]
-        public void BasicAuthroization_IsConfigurableWith_ColonNotation_AndBasicExplicitlyDeclared() {
+        public void BasicAuthorization_IsConfigurableWith_ColonNotation_AndBasicExplicitlyDeclared() {
             const string expectedBody = "resource has been created";
             var request = WebRequest.Create("http://localhost:9992/post/auth/pair/extrabasic");
             request.Method = "post";
@@ -236,7 +236,7 @@ namespace integration {
             var actualBody = TestUtils.ExtractBody(response);
             stopwatch.Stop();
 
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds > 2000, "Responded too soon");
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 2000, "Responded too soon");
             Assert.IsTrue(stopwatch.ElapsedMilliseconds < 2500, "Responded too late");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.AreEqual(expectedBody, actualBody);

--- a/integration/YAML/e2e.yaml
+++ b/integration/YAML/e2e.yaml
@@ -58,8 +58,8 @@
     url: /get/query
     method: GET
     query:
-      first: 'value1again'
-      second: 'value2again'
+      first: 'valueagain1'
+      second: 'valueagain2'
   response:
     status: 200
     body: second query

--- a/integration/YAML/invocations.yaml
+++ b/integration/YAML/invocations.yaml
@@ -1,0 +1,3 @@
+- request:
+    url: /basic
+    method: [put, post, delete, get]

--- a/integration/integration.csproj
+++ b/integration/integration.csproj
@@ -10,10 +10,7 @@
     <AssemblyName>integration</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <!--<ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>-->
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
@@ -43,6 +40,7 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Extensions" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -53,6 +51,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="InvocationsTest.cs" />
     <Compile Include="TestUtils.cs" />
     <Compile Include="ViaFileTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -60,6 +59,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="YAML\invocations.yaml" />
     <None Include="YAML\e2e.yaml" />
     <None Include="YAML\endpoints.file" />
   </ItemGroup>
@@ -81,7 +81,6 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/stubby/Domain/Endpoint.cs
+++ b/stubby/Domain/Endpoint.cs
@@ -1,5 +1,8 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Collections.Specialized;
+using System.Net;
+using System.Runtime.Serialization;
 using System.Collections.Generic;
+using stubby.Portals;
 
 namespace stubby.Domain {
 

--- a/stubby/Domain/Invocation.cs
+++ b/stubby/Domain/Invocation.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Net;
+using System.Runtime.Serialization;
+using System.Text;
+using stubby.Portals;
+using System.Linq;
+
+namespace stubby.Domain
+{
+	[DataContract]
+	public class Invocation
+	{
+		/// <summary>
+		/// A regex string to match incoming URI paths to. Incoming query parameters are ignored.
+		/// </summary>
+		[DataMember]
+		public string Url { get; set; }
+
+		/// <summary>
+		/// A list of acceptable HTTP verbs such as GET or POST.
+		/// </summary>
+		[DataMember]
+		public string Method { get; set; }
+
+		/// <summary>
+		/// Name/Value headers that incoming requests must at least possess.
+		/// </summary>
+		[DataMember]
+		public IDictionary<string, IList<string>> Headers { get; set; }
+
+		/// <summary>
+		/// A Name/Value collection of URI Query parameters that must be present.
+		/// </summary>
+		[DataMember]
+		public IDictionary<string, IList<string>> Query { get; set; }
+
+		/// <summary>
+		/// The post body contents of the incoming request. If File is specified and exists upon request, this value is ignored.
+		/// </summary>
+		[DataMember]
+		public string Post { get; set; }
+
+		public override string ToString()
+		{
+			var query = ToString(Query, "&");
+			var headers = ToString(Headers, ",");
+			return string.Format("{0}: {1}{2}{3} Headers: {4}, Body: {5}",
+			                     Method,
+			                     Url,
+			                     string.IsNullOrEmpty(query) ? string.Empty : "?",
+								 query,
+			                     headers,
+			                     Post);
+		}
+
+		private static string ToString(IDictionary<string, IList<string>> dict, string separator)
+		{
+			var str = new StringBuilder();
+			foreach (var entry in dict)
+			{
+				var valueString = string.Join(",", entry.Value);
+				str.AppendFormat("{0}={1}{2}", entry.Key, valueString, separator);
+			}
+			if (str.Length > 0)
+				str.Length -= separator.Length;
+
+			return str.ToString();
+		}
+	}
+}

--- a/stubby/Domain/InvocationDb.cs
+++ b/stubby/Domain/InvocationDb.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace stubby.Domain
+{
+	internal class InvocationDb
+	{
+		private readonly IDictionary<string, IDictionary<string, IList<Invocation>>> _invocations = new Dictionary<string, IDictionary<string, IList<Invocation>>>();
+
+		public void Add(Invocation invocation)
+		{
+			IDictionary<string, IList<Invocation>> verbInvocations;
+			if (!_invocations.TryGetValue(invocation.Method, out verbInvocations))
+			{
+				lock (_invocations)
+				{
+					if (!_invocations.TryGetValue(invocation.Method, out verbInvocations))
+					{
+						verbInvocations = new Dictionary<string, IList<Invocation>>();
+						verbInvocations[invocation.Url] = new List<Invocation>();
+						_invocations[invocation.Method] = verbInvocations;
+					}
+				}
+			}
+
+			IList<Invocation> urlInvocations;
+			if (!verbInvocations.TryGetValue(invocation.Url, out urlInvocations))
+			{
+				lock (verbInvocations)
+				{
+					if (!verbInvocations.TryGetValue(invocation.Url, out urlInvocations))
+					{
+						urlInvocations = new List<Invocation>();
+						verbInvocations[invocation.Url] = urlInvocations;
+					}
+				}
+			}
+
+			lock (urlInvocations)
+				urlInvocations.Add(invocation);
+		}
+
+		private IList<Invocation> GetInvocations(Invocation incoming)
+		{
+			IDictionary<string, IList<Invocation>> verbInvocations;
+			if (!_invocations.TryGetValue(incoming.Method, out verbInvocations))
+				return new List<Invocation>();
+
+			IList<Invocation> invocations;
+			if (!verbInvocations.TryGetValue(incoming.Url, out invocations))
+				return new List<Invocation>();
+
+			return invocations;
+		}
+
+		public IList<Invocation> Find(Invocation incoming)
+		{
+			var invocations = GetInvocations(incoming);
+			lock (invocations)
+				return invocations.Where(i => IsMatched(i, incoming)).ToList();
+		}
+
+		private static bool IsMatched(Invocation invocation, Invocation incoming)
+		{
+			if (!IsMatched(invocation.Headers, incoming.Headers))
+				return false;
+
+			if (!IsMatched(invocation.Query, incoming.Query))
+				return false;
+
+			return String.IsNullOrEmpty(incoming.Post) ||
+			       String.Equals(invocation.Post, incoming.Post, StringComparison.OrdinalIgnoreCase);
+		}
+
+		private static bool IsMatched(IDictionary<string, IList<string>> invocation, IDictionary<string, IList<string>> incoming)
+		{
+			if (invocation == incoming)
+				return true;
+
+			if (invocation == null || incoming == null)
+				return false;
+
+			foreach (var incomingEntry in incoming)
+			{
+				var key = incomingEntry.Key;
+				if (!invocation.ContainsKey(key))
+					return false;
+
+				if (!incomingEntry.Value.Any())
+					continue;
+
+				if (!incomingEntry.Value.All(x => invocation[key].Any(y => String.Equals(x, y, StringComparison.OrdinalIgnoreCase))))
+					return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/stubby/Portals/PortalUtils.cs
+++ b/stubby/Portals/PortalUtils.cs
@@ -1,114 +1,187 @@
 ﻿using System;
-using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Net;
-using System.Runtime.Serialization.Json;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using stubby.CLI;
 using System.Web.Script.Serialization;
+using stubby.Domain;
 
 namespace stubby.Portals {
 
-    internal static class PortalUtils {
-        private const string RequestResponseFormat = "[{0}] {1} {2} [{3}]{4} {5}";
-        private const string ListeningString = "{0} portal listening at http{3}://{1}:{2}";
-        private const string IncomingArrow = "->";
-        private const string OutgoingArrow = "<-";
-        private const string JsonMimeType = "application/json";
-        private const string HtmlMimeType = "text/html";
-        private static readonly string ServerHeader = "stubby4net/" + Stubby.Version;
+	internal static class PortalUtils
+	{
+		private const string RequestResponseFormat = "[{0}] {1} {2} [{3}]{4} {5}";
+		private const string ListeningString = "{0} portal listening at http{3}://{1}:{2}";
+		private const string IncomingArrow = "->";
+		private const string OutgoingArrow = "<-";
+		private const string JsonMimeType = "application/json";
+		private const string HtmlMimeType = "text/html";
+		private static readonly string ServerHeader = "stubby4net/" + Stubby.Version;
 
-        public static void PrintIncoming(string portal, HttpListenerContext context, string message = "") {
-            var url = context.Request.Url.AbsolutePath;
-            var method = context.Request.HttpMethod;
+		public static void PrintIncoming(string portal, HttpListenerContext context, string message = "")
+		{
+			var url = context.Request.Url.AbsolutePath;
+			var method = context.Request.HttpMethod;
 
-            Out.Incoming(string.Format(RequestResponseFormat,
-                                       DateTime.Now.ToString("T"), IncomingArrow, method, portal, url, message));
-        }
+			Out.Incoming(String.Format(RequestResponseFormat,
+			                           DateTime.Now.ToString("T"), IncomingArrow, method, portal, url, message));
+		}
 
-        public static void PrintOutgoing(string portal, HttpListenerContext context, string message = "") {
-            var url = context.Request.Url.AbsolutePath;
-            var status = context.Response.StatusCode;
-            var now = DateTime.Now.ToString("T");
-            Action<string> function;
+		public static void PrintOutgoing(string portal, HttpListenerContext context, string message = "")
+		{
+			var url = context.Request.Url.AbsolutePath;
+			var status = context.Response.StatusCode;
+			var now = DateTime.Now.ToString("T");
+			Action<string> function;
 
-            if(status < 200)
-                function = Out.Info;
-            else if(status < 300)
-                function = Out.Success;
-            else if(status < 400)
-                function = Out.Warn;
-            else
-                function = Out.Error;
+			if (status < 200)
+				function = Out.Info;
+			else if (status < 300)
+				function = Out.Success;
+			else if (status < 400)
+				function = Out.Warn;
+			else
+				function = Out.Error;
 
-            function.Invoke(String.Format(RequestResponseFormat, now, OutgoingArrow, status, portal, url, message));
-        }
+			function.Invoke(String.Format(RequestResponseFormat, now, OutgoingArrow, status, portal, url, message));
+		}
 
-        public static void SetServerHeader(HttpListenerContext context) {
-            context.Response.AddHeader("Server", ServerHeader);
-        }
+		public static void SetServerHeader(HttpListenerContext context)
+		{
+			context.Response.AddHeader("Server", ServerHeader);
+		}
 
-        public static void SetJsonType(HttpListenerContext context) {
-            context.Response.Headers.Set(HttpResponseHeader.ContentType, JsonMimeType);
-        }
+		public static void SetJsonType(HttpListenerContext context)
+		{
+			context.Response.Headers.Set(HttpResponseHeader.ContentType, JsonMimeType);
+		}
 
-        public static void SetHtmlType(HttpListenerContext context) {
-            context.Response.Headers.Set(HttpResponseHeader.ContentType, HtmlMimeType);
-        }
+		public static void SetHtmlType(HttpListenerContext context)
+		{
+			context.Response.Headers.Set(HttpResponseHeader.ContentType, HtmlMimeType);
+		}
 
-        public static void SerializeToJson<T>(T entity, HttpListenerContext context) {
-            var serializer = new JavaScriptSerializer();
-            SetJsonType(context);
+		public static void SerializeToJson<T>(T entity, HttpListenerContext context)
+		{
+			var serializer = new JavaScriptSerializer();
+			SetJsonType(context);
 			WriteBody(context, serializer.Serialize(entity));
-        }
+		}
 
-        public static void WriteBody(HttpListenerContext context, string body) {
-            using(var writer = new StreamWriter(context.Response.OutputStream)) {
-                writer.Write(body);
-            }
-        }
+		public static void WriteBody(HttpListenerContext context, string body)
+		{
+			using (var writer = new StreamWriter(context.Response.OutputStream))
+			{
+				writer.Write(body);
+			}
+		}
 
-        public static string ReadPost(HttpListenerRequest request) {
-            if(request.ContentLength64.Equals(0))
-                return null;
-            using(var reader = new StreamReader(request.InputStream)) {
-                return reader.ReadToEnd();
-            }
-        }
+		public static string ReadPost(HttpListenerRequest request)
+		{
+			if (request.ContentLength64.Equals(0))
+				return null;
+			using (var reader = new StreamReader(request.InputStream))
+			{
+				return reader.ReadToEnd();
+			}
+		}
 
-        public static string BuildUri(string location, uint port, bool https = false) {
-            var stringBuilder = new StringBuilder("");
+		public static string BuildUri(string location, uint port, bool https = false)
+		{
+			var stringBuilder = new StringBuilder("");
 
-            stringBuilder.Append(https ? "https://" : "http://");
-            stringBuilder.Append(location);
-            stringBuilder.Append(":");
-            stringBuilder.Append(port);
-            stringBuilder.Append("/");
+			stringBuilder.Append(https ? "https://" : "http://");
+			stringBuilder.Append(location);
+			stringBuilder.Append(":");
+			stringBuilder.Append(port);
+			stringBuilder.Append("/");
 
-            return stringBuilder.ToString();
-        }
+			return stringBuilder.ToString();
+		}
 
-        public static byte[] GetBytes(string str) {
-            var bytes = new byte[str.Length * sizeof(char)];
-            Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
-            return bytes;
-        }
+		public static byte[] GetBytes(string str)
+		{
+			var bytes = new byte[str.Length * sizeof (char)];
+			Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
+			return bytes;
+		}
 
-        public static void PrintListening(string name, string location, uint port, bool https = false) {
-            Out.Status(string.Format(ListeningString, name, location, port, https ? "s" : String.Empty));
-        }
+		public static void PrintListening(string name, string location, uint port, bool https = false)
+		{
+			Out.Status(String.Format(ListeningString, name, location, port, https ? "s" : String.Empty));
+		}
 
-        public static void SetStatus(HttpListenerContext context, int status) {
-            context.Response.StatusCode = status;
-        }
+		public static void SetStatus(HttpListenerContext context, int status)
+		{
+			context.Response.StatusCode = status;
+		}
 
-        public static void SetStatus(HttpListenerContext context, HttpStatusCode status) {
-            SetStatus(context, (int) status);
-        }
+		public static void SetStatus(HttpListenerContext context, HttpStatusCode status)
+		{
+			SetStatus(context, (int) status);
+		}
 
-        public static void AddLocationHeader(HttpListenerContext context, uint id) {
-            context.Response.Headers.Add(HttpResponseHeader.Location, "/" + id);
-        }
-    }
+		public static void AddLocationHeader(HttpListenerContext context, uint id)
+		{
+			context.Response.Headers.Add(HttpResponseHeader.Location, "/" + id);
+		}
+	}
+
+	public static class Extensions
+	{
+		internal static Invocation ToInvocation(this HttpListenerContext context)
+		{
+			return context.ToEndpoint().ToInvocation();
+		}
+
+		internal static Invocation ToInvocation(this Endpoint endpoint)
+		{
+			return new Invocation
+			{
+				Url = endpoint.Request.Url,
+				Method = endpoint.Request.Method[0],
+				Headers = ToDictionary(endpoint.Request.Headers),
+				Query = ToDictionary(endpoint.Request.Query),
+				Post = endpoint.Request.Post
+			};
+		}
+
+		internal static Endpoint ToEndpoint(this HttpListenerContext context)
+		{
+			return new Endpoint
+			{
+				Request =
+				{
+					Url = context.Request.Url.AbsolutePath,
+					Method = new List<string> { context.Request.HttpMethod.ToUpper() },
+					Headers = CreateNameValueCollection(context.Request.Headers, caseSensitiveKeys: false),
+					Query = CreateNameValueCollection(context.Request.QueryString, caseSensitiveKeys: true),
+					Post = PortalUtils.ReadPost(context.Request)
+				}
+			};
+		}
+
+		private static IDictionary<string, IList<string>> ToDictionary(NameValueCollection nvc)
+		{
+			var result = new Dictionary<string, IList<string>>();
+			foreach (string key in nvc.Keys)
+			{
+				var values = nvc.GetValues(key);
+				result.Add(key.ToLowerInvariant(), values == null ? new List<string>() : new List<string>(values));
+			}
+			return result;
+		}
+
+		private static NameValueCollection CreateNameValueCollection(NameValueCollection collection, bool caseSensitiveKeys)
+		{
+			var newCollection = new NameValueCollection();
+			foreach (var key in collection.AllKeys)
+			{
+				newCollection.Add(caseSensitiveKeys ? key : key.ToLower(), collection.Get(key));
+			}
+			return newCollection;
+		}
+	}
 }

--- a/stubby/Stubby.cs
+++ b/stubby/Stubby.cs
@@ -19,6 +19,7 @@ namespace stubby {
         internal static readonly string Version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
         private readonly FileSystemWatcher _watcher = new FileSystemWatcher();
         private readonly EndpointDb _endpointDb = new EndpointDb();
+		private readonly InvocationDb _invocationDb = new InvocationDb();
         private readonly IArguments _arguments;
         private readonly Admin _admin;
         private readonly Stubs _stubs;
@@ -35,8 +36,8 @@ namespace stubby {
         /// <param name="arguments">The collection of options used by stubby.</param>
         public Stubby(IArguments arguments) {
             _arguments = arguments ?? new Arguments { Mute = true };
-            _admin = new Admin(_endpointDb);
-            _stubs = new Stubs(_endpointDb);
+			_admin = new Admin(_endpointDb, _invocationDb);
+			_stubs = new Stubs(_endpointDb, _invocationDb);
 
             Out.Mute = _arguments.Mute;
             LoadEndpoints();

--- a/stubby/stubby.csproj
+++ b/stubby/stubby.csproj
@@ -39,7 +39,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <Commandlineparameters></Commandlineparameters>
+    <Commandlineparameters>
+    </Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -82,6 +83,8 @@
     <Compile Include="Domain\ComparisonUtils.cs" />
     <Compile Include="Domain\Endpoint.cs" />
     <Compile Include="Domain\EndpointDb.cs" />
+    <Compile Include="Domain\Invocation.cs" />
+    <Compile Include="Domain\InvocationDb.cs" />
     <Compile Include="Domain\Request.cs" />
     <Compile Include="Domain\Response.cs" />
     <Compile Include="Exceptions\EndpointParsingException.cs" />

--- a/unit/InvocationDbTest.cs
+++ b/unit/InvocationDbTest.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using stubby.CLI;
+using stubby.Domain;
+
+namespace unit
+{
+	[TestFixture]
+	class InvocationDbTest
+	{
+		private InvocationDb _invocationDb;
+
+		[SetUp]
+		public void BeforeEach()
+		{
+			Out.Mute = true;
+			_invocationDb = new InvocationDb();
+		}
+
+		[Test]
+		public void Add_ShouldIndexByMethodAndUrl()
+		{
+			var random = new Random();
+			var verbs = new[] {"GET", "PUT", "POST", "DELETE", "HEAD"};
+
+			var invocations = new List<Invocation>();
+			for (var i = 0; i < verbs.Length; i++)
+			{
+				var verb = verbs[i];
+				var invocationCount = random.Next(5, 100);
+				for (var j = 0; j < invocationCount; j++)
+				{
+					var resourceName = "/resource" + random.Next(1, 10);
+					invocations.Add(new Invocation {Method = verb, Url = resourceName});
+				}
+			}
+
+			invocations.ForEach(i => _invocationDb.Add(i));
+
+			var invocationDict = invocations.GroupBy(x => x.Method)
+				.ToDictionary(k1 => k1.Key, v1 => v1.GroupBy(x => x.Url).ToDictionary(k2 => k2.Key, v2 => v2.ToList()));
+
+			foreach (var methodEntry in invocationDict)
+			{
+				var method = methodEntry.Key;
+				foreach (var urlEntry in methodEntry.Value)
+				{
+					var url = urlEntry.Key;
+					var expectedInvocations = urlEntry.Value;
+					var actualInvocations = _invocationDb.Find(new Invocation {Method = method, Url = url});
+					Assert.That(expectedInvocations.Count, Is.EqualTo(actualInvocations.Count));
+				}
+			}
+		}
+
+		[Test]
+		public void Find_ShouldReturnEmptyList_WhenEmpty()
+		{
+			var invocations = _invocationDb.Find(new Invocation {Method = "GET"});
+			Assert.That(invocations.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void Find_ShouldReturnEmptyList_WhenEmptyUrls()
+		{
+			_invocationDb.Add(new Invocation { Method = "GET", Url = "/url1"});
+			var invocations = _invocationDb.Find(new Invocation { Method = "GET", Url = "/url2" });
+			Assert.That(invocations.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void Find_ShouldNotMatch_WhenIncomingHeaderIsNull()
+		{
+			_invocationDb.Add(new Invocation {Method = "GET", Url = "/url1", Headers = new Dictionary<string, IList<string>>()});
+			var invocations = _invocationDb.Find(new Invocation { Method = "GET", Url = "/url1" });
+			Assert.That(invocations.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void Find_ShouldNotMatch_WhenInvocationHeaderIsNull()
+		{
+			_invocationDb.Add(new Invocation { Method = "GET", Url = "/url1"});
+			var invocations = _invocationDb.Find(new Invocation {Method = "GET", Url = "/url1", Headers = new Dictionary<string, IList<string>>()});
+			Assert.That(invocations.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void Find_ShouldNotMatch_WhenInvocationQueryIsNull()
+		{
+			_invocationDb.Add(new Invocation { Method = "GET", Url = "/url1" });
+			var invocations = _invocationDb.Find(new Invocation { Method = "GET", Url = "/url1", Query = new Dictionary<string, IList<string>>() });
+			Assert.That(invocations.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void Find_ShouldNotMatch_WhenInvocationHeadersDoNotHaveIncomingHeaderKey()
+		{
+			var invocationHeader = new Dictionary<string, IList<string>> {{"header1", new List<string>()}};
+			var incomingHeader = new Dictionary<string, IList<string>> {{"header2", new List<string>()}};
+
+			_invocationDb.Add(new Invocation { Method = "GET", Url = "/url1", Headers = invocationHeader });
+			var invocations = _invocationDb.Find(new Invocation {Method = "GET", Url = "/url1", Headers = incomingHeader});
+			Assert.That(invocations.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void Find_ShouldMatch_WhenInvocationHeaderExistsButIncomingHeaderHasNoValues()
+		{
+			var invocationHeader = new Dictionary<string, IList<string>> {{"header1", new List<string> {"a", "b", "c"}}};
+			var incomingHeader = new Dictionary<string, IList<string>> {{"header1", new List<string>()}};
+
+			_invocationDb.Add(new Invocation { Method = "GET", Url = "/url1", Headers = invocationHeader });
+			var invocations = _invocationDb.Find(new Invocation { Method = "GET", Url = "/url1", Headers = incomingHeader });
+			Assert.That(invocations.Count, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void Find_ShouldNotMatch_WhenInvocationHeadersDoNotHaveIncomingHeaderValue()
+		{
+			var invocationHeader = new Dictionary<string, IList<string>> { { "header1", new List<string> { "a", "b", "c" } } };
+			var incomingHeader = new Dictionary<string, IList<string>> { { "header1", new List<string> { "d" } } };
+
+			_invocationDb.Add(new Invocation { Method = "GET", Url = "/url1", Headers = invocationHeader });
+			var invocations = _invocationDb.Find(new Invocation { Method = "GET", Url = "/url1", Headers = incomingHeader });
+			Assert.That(invocations.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void Find_ShouldMatch_WhenMultipleInvocationHeadersMatchIncomingHeaders()
+		{
+			var invocationHeader = new Dictionary<string, IList<string>>
+			{
+				{ "header1", new List<string> { "a", "b", "c" } },
+				{ "header2", new List<string> { "d", "e", "f" } }
+			};
+			var incomingHeader = new Dictionary<string, IList<string>>
+			{
+				{ "header1", new List<string> { "a" } },
+				{ "header2", new List<string> { "d" } },
+			};
+
+			_invocationDb.Add(new Invocation { Method = "GET", Url = "/url1", Headers = invocationHeader });
+			var invocations = _invocationDb.Find(new Invocation { Method = "GET", Url = "/url1", Headers = incomingHeader });
+			Assert.That(invocations.Count, Is.EqualTo(1));
+		}
+	}
+}

--- a/unit/unit.csproj
+++ b/unit/unit.csproj
@@ -10,10 +10,7 @@
     <AssemblyName>unit</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <!--<ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>-->
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
@@ -56,6 +53,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="EndointContractTest.cs" />
+    <Compile Include="InvocationDbTest.cs" />
     <Compile Include="PortalUtilsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EndpointDbTest.cs" />
@@ -99,7 +97,6 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Hi Eric,

First off, just want to thank you for creating stub.by - it's a great tool and it has been proving itself very useful at our company.  We have many teams working on applications that integrate with other teams' apps using RESTful services so you can imagine how much value your tool has added, especially in our dev and testing automation environments.

There is a feature that we would find useful, which I wasn't able to find in the existing stubby implementation.  This feature is the ability to validate data that gets sent to stubby, and the ability to track (and query) all invocations that were performed against stubby.

This pull request implements that feature, and we basically keep a track of an Invocation object every time a stub is invoked.  You can have a look at the Invocation class below but it's very similar to the Endpoint class.  These invocations are then kept in memory, in a dictionary of dictionaries of lists (just for the purposes of indexing and performance) and can be queried through the admin interface at the /invocations/ path.

We have an internal NuGet server where I will share this code with the rest of our organization but I thought you may be interested in having a look at this as well.  Let me know what you think, if you'd be interested in including these changes in your project, and if so, if there's more work you'd expect before you accept the pull request and add this feature to NuGet.

Either way, thank you once again, you're making lives easier, at least at our company :)

Greg
